### PR TITLE
Highlight on key press option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A Vim plugin that highlights which characters to target for <kbd>f</kbd>, <kbd>F
   + [Benefits](#benefits)
 + [Installation](#installation)
 + [Options](#options)
+  + [Highlight on key press](#highlight-on-key-press)
   + [Customize colors](#customize-colors)
   + [Toggle highlighting](#toggle-highlighting)
 + [Moving Across a Line](#moving-across-a-line)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ $ git clone https://github.com/unblevable/quick-scope ~/.vim/bundle/quick-scope 
 ```
 
 ## Options
+### Highlight on key press
+```vim
+" Your .vimrc
+
+" Trigger a highlight in the appropriate direction when pressing these keys:
+let g:qs_highlight_on_keys = ['f', 'F', 't', 'T']
+
+" Trigger a highlight only when pressing f and F.
+let g:qs_highlight_on_keys =  ['f', 'F']
+```
+
 ### Customize colors
 ```vim
 " Your .vimrc

--- a/doc/quick-scope.txt
+++ b/doc/quick-scope.txt
@@ -1,6 +1,6 @@
 *quick-scope.txt*
 
-Version:    1.0.0
+Version:    1.1.0
 Homepage:   https://github.com/unblevable/quick-scope
 Author:     Brian Le (unblevable)
 License:    MIT
@@ -13,8 +13,9 @@ License:    MIT
     2.1 Example ............................... |qs-example|
   3. Features ................................. |qs-features|
   4. Options .................................. |qs-options|
-    4.1 Customize colors ...................... |qs-customize-colors|
-    4.2 Toggle highlighting ................... |qs-toggle-highlighting|
+    4.1 Highlight on key press ................ |qs-highlight-on-key-press|
+    4.2 Customize colors ...................... |qs-customize-colors|
+    4.3 Toggle highlighting ................... |qs-toggle-highlighting|
   5. Motivation ............................... |qs-motivation|
   6. Bugs ..................................... |qs-bugs|
     6.1 Known bugs ............................ |qs-known-bugs|
@@ -83,7 +84,19 @@ move to it.
  4. OPTIONS                                                       *qs-options*
 ==============================================================================
 
- 4.1 CUSTOMIZE COLORS                                    *qs-customize-colors*
+ 4.1 HIGHLIGHT ON KEY PRESS                        *qs-highlight-on-key-press*
+------------------------------------------------------------------------------
+
+                                                      *g:qs_highlight_on_keys*
+Trigger a highlight in the appropriate direction when pressing these keys:
+>
+  let g:qs_highlight_on_keys = ['f', 'F', 't', 'T']
+<
+Trigger a highlight only when pressing |f| and |F|.
+>
+  let g:qs_highlight_on_keys = ['f', 'F']
+<
+ 4.2 CUSTOMIZE COLORS                                    *qs-customize-colors*
 ------------------------------------------------------------------------------
 
                                        *g:qs_first_occurrence_highlight_color*
@@ -110,7 +123,7 @@ Terminal Vim~
 >
   let g:qs_second_occurrence_highlight_color = 81
 <
- 4.2 TOGGLE HIGHLIGHTING                              *qs-toggle-highlighting*
+ 4.3 TOGGLE HIGHLIGHTING                              *qs-toggle-highlighting*
 ------------------------------------------------------------------------------
 
                                                            *:QuickScopeToggle*
@@ -151,7 +164,7 @@ http://github.com/unblevable/quick-scope/issues
   the cursor moves.
 
   Let me know if this plugin slows down Vim to an unmanageable level. Using
-  |:QuickScopeToggle| make sure that it is acutally this plugin that is
+  |:QuickScopeToggle|, make sure that it is actually this plugin that is
   causing performance problems you are experiencing.
 
  7. CHANGELOG                                                   *qs-changelog*
@@ -159,15 +172,17 @@ http://github.com/unblevable/quick-scope/issues
 
  Version   Date         Release Notes~
 |---------|-----------|-----------------------------------------------------------|
+ 1.1.0     2015-08-20 * Added
+                        - Added |g:qs_highlight_on_keys| option
  1.0.1     2015-08-02 * Changed
                         - Made the help doc link consistent with the plugin's
-                          name (quick-scope).
+                          name (quick-scope)
                         Fixed
                         - The highlight color selection on startup is more
                           robust.
-                        - Works with Neovim with true color enabled.
+                        - Works with Neovim with true color enabled
 |---------|-----------|-----------------------------------------------------------|
- 1.0.0     2015-08-02 * Initial upload.
+ 1.0.0     2015-08-02 * Initial upload
 
 ==============================================================================
 vim:tw=78:sw=2:ts=2:ft=help:norl:nowrap:

--- a/plugin/quick_scope.vim
+++ b/plugin/quick_scope.vim
@@ -1,4 +1,4 @@
-" Initialize ------------------------------------------------------------------
+" Initialize -----------------------------------------------------------------
 let s:plugin_name = "quick-scope"
 
 if exists('g:loaded_quick_scope')
@@ -24,7 +24,7 @@ unlet! s:plugin_name
 let s:cpo_save = &cpo
 set cpo&vim
 
-" Options ---------------------------------------------------------------------
+" Options --------------------------------------------------------------------
 if !exists('g:qs_enable')
   let g:qs_enable = 1
 endif
@@ -49,7 +49,7 @@ else
   endfor
 endif
 
-" User commands ---------------------------------------------------------------
+" User commands --------------------------------------------------------------
 function! s:toggle()
   if g:qs_enable
     let g:qs_enable = 0
@@ -62,11 +62,11 @@ endfunction
 
 command! -nargs=0 QuickScopeToggle call s:toggle()
 
-" Plug mappings ---------------------------------------------------------------
+" Plug mappings --------------------------------------------------------------
 nnoremap <silent> <plug>(QuickScopeToggle) :call <sid>toggle()<cr>
 vnoremap <silent> <plug>(QuickScopeToggle) :<c-u>call <sid>toggle()<cr>
 
-" Colors ----------------------------------------------------------------------
+" Colors ---------------------------------------------------------------------
 " Detect if the running instance of Vim acts as a GUI or terminal.
 function! s:get_term()
   if has('gui_running') || (has('nvim') && $NVIM_TUI_ENABLE_TRUE_COLOR)
@@ -151,7 +151,7 @@ endfunction
 
 call s:set_highlight_colors()
 
-" Main highlighting functions -------------------------------------------------
+" Main highlighting functions ------------------------------------------------
 " Apply the highlights for each highlight group based on pattern strings.
 "
 " Arguments are expected to be lists of two items.
@@ -321,7 +321,7 @@ function! s:unhighlight_line()
   endfor
 endfunction
 
-" Highlight on key press ------------------------------------------------------
+" Highlight on key press -----------------------------------------------------
 " Manage state for keeping or removing the extra highlight after triggering a
 " highlight on key press.
 "
@@ -389,8 +389,8 @@ function! s:aim(motion)
   set t_ve=
   set guicursor=n:block-NONE
 
-  " Silence 'Type :quit<Enter> to exit Vim' message on <c-c> during a character
-  " search.
+  " Silence 'Type :quit<Enter> to exit Vim' message on <c-c> during a
+  " character search.
   "
   " This line also causes getchar() to cleanly cancel on a <c-c>.
   execute 'nnoremap <silent> <c-c> <c-c>'
@@ -424,12 +424,12 @@ function! s:reload()
   return ''
 endfunction
 
-" Trigger an extra highlight for a target character only if it originally had a
-" secondary highlight.
+" Trigger an extra highlight for a target character only if it originally had
+" a secondary highlight.
 function! s:double_tap()
   if index(s:chars_s, s:target) != -1
-    " Warning: slight hack below. Although the cursor has already moved by this
-    " point, col('.') won't return the updated cursor position until the
+    " Warning: slight hack below. Although the cursor has already moved by
+    " this point, col('.') won't return the updated cursor position until the
     " invoking mapping completes. So when highlight_line() is called here, the
     " first occurrence of the target will be under the cursor, and the second
     " occurrence will be where the first occurence should have been.
@@ -445,7 +445,8 @@ function! s:double_tap()
     " highlight color.
     call s:add_to_highlight_group(s:hi_group_secondary, 'fg', g:qs_first_occurrence_highlight_color)
 
-    " Set a temporary event to keep track of when to reset the extra highlight.
+    " Set a temporary event to keep track of when to reset the extra
+    " highlight.
     augroup quick_scope
       autocmd CursorMoved * call s:handle_extra_highlight(1)
     augroup END


### PR DESCRIPTION
Issue #2.

Added option `g:qs_highlight_on_keys`:

``` vim
" Trigger a highlight for all character motions
g:qs_highlight_on_keys = ['f', 'F', 't', 'T']

" Trigger a highlight for just 'f' and 'F'
g:qs_highlight_on_keys = ['f', 'F']
```

Here is an updated task list:
- [x] Trigger a highlight on any of <kbd>f</kbd>, <kbd>F</kbd>, <kbd>t</kbd> or <kbd>T</kbd>.
- [x] Trigger only a forward highlight on <kbd>f</kbd> and <kbd>t</kbd> and only a backward highlight on <kbd>F</kbd> and <kbd>T</kbd>.
- [x]  After executing a character motion, trigger an "extra" highlight for the target character only if it originally had a second-occurrence highlight.
  
  (I don't have access to my computer with screen capture software at the moment, so you're going to have to try this pull request out yourself if the description wasn't clear for you).
  
  After a lot of fiddling around, I've decided that this is probably the best solution for quick-scope:
  - It keeps the plugin simple: user locks eyes on a word ⇨ user targets highlighted character in that word ⇨ character in that word remains highlighted until the user moves to the word (or cancels the highlight).
  - This option is for users who felt that quick-scope's default behavior was too distracting, and in my opinion, this is a pretty un-distracting enhancement.
  - It mirrors the default behavior of quick-scope in a way.
- [x] If `g:qs_highlight_on_keys` is enabled, avoid using autocommands if possible.
- [x] Keep the cursor visible during the character motion.
- [x] Add documentation to README and help docs.
