### PR TITLE
Added multibyte support

### DIFF
--- a/plugin/quick_scope.vim
+++ b/plugin/quick_scope.vim
@@ -208,7 +208,7 @@ function! s:get_highlight_patterns(line, cursor, end)
 
     " catch cases where multibyte chars may result in c not exactly equal to
     " a:end
-    while (direction && c <= a:end || !direction && c >= a:end - 1)
+    while (direction && c <= a:end || !direction && c >= a:end)
 
         let char = matchstr(a:line, ".", byteidx(a:line, i))
 
@@ -285,7 +285,7 @@ function! s:highlight_line()
             call s:apply_highlight_patterns([patt_p, patt_s])
 
             " Highlights before the cursor.
-            let [patt_p, patt_s] = s:get_highlight_patterns(line, pos, 0)
+            let [patt_p, patt_s] = s:get_highlight_patterns(line, pos, 1)
             call s:apply_highlight_patterns([patt_p, patt_s])
         endif
     endif


### PR DESCRIPTION
Issue #7.

Added multibyte support. The `accepted_chars` dictionary still has to be manually modified to include those multibyte characters.

The loop logic has been slightly modified to take into account the multibyte characters and the fact that `\%c` refers to the byte column.

Quick tests have been done on multibyte chars and chars with `strdisplaywidth` larger than 1.

Further tests should be done to make sure it works in all scenarios.
