### PR TITLE
Check empty bg_color in s:add_to_highlight_group

### DIFF
--- a/plugin/quick_scope.vim
+++ b/plugin/quick_scope.vim
@@ -150,7 +150,7 @@ function! s:set_highlight_colors()
   if &cursorline
     let bg_color = synIDattr(synIDtrans(hlID('CursorLine')), 'bg', s:get_term())
 
-    if bg_color != -1
+    if bg_color != -1 && bg_color != ''
       call s:add_to_highlight_group(s:hi_group_primary, 'bg', bg_color)
       call s:add_to_highlight_group(s:hi_group_secondary, 'bg', bg_color)
     endif


### PR DESCRIPTION
When using your plugin on my computer, Vim gave this error when starting:

> Error detected while processing function <SNR>25_set_highlight_colors..<SNR>25_add_to_highlight_group:
> line 1:
> E417: missing argument: guibg=
> E417: missing argument: guibg=

I tracked the problem down to a syntax check in s:add_to_highlight group. Basically, my colorscheme (and I'm guessing others could do this too) has an empty field instead of none for the background color. I should probably fix my colorscheme too, but I figure this makes your plugin more robust. 

PS. I did check, it does work! :) Thanks for this cool plugin!

Best,
Case
