### PR TITLE
Disable highlighting on long lines (issue #23)

### DIFF
--- a/plugin/quick_scope.vim
+++ b/plugin/quick_scope.vim
@@ -34,6 +34,11 @@ if !exists('g:qs_enable')
   let g:qs_enable = 1
 endif
 
+if !exists('g:qs_max_chars')
+  " Disable on long lines for performance
+  let g:qs_max_chars = 1000
+endif
+
 " Change this to an option for a future update...
 if !exists('s:accepted_chars')
   " Keys correspond to characters that can be highlighted. Values aren't used.
@@ -304,7 +309,7 @@ function! s:highlight_line(direction, targets)
     let len = strlen(line)
     let pos = col('.')
 
-    if !empty(line)
+    if !empty(line) && len <= g:qs_max_chars
       " Highlight after the cursor.
       if a:direction != 0
         let [patt_p, patt_s] = s:get_highlight_patterns(line, pos, len, a:targets)


### PR DESCRIPTION
When quick-scope is enabled on long lines, performance degrades. In
extreme cases, e.g. lines with 800000+ characters, vim hangs completely (or
processing takes unbearably long).

The solution proposed in pull request #29 was to process up to the first X
(e.g. 1000) characters. While this stops vim from hanging, it still causes
noticeable delays when scrolling through the document across the long line,
even when X=10.

This commit implements a different solution: disable all quick-scope
highlighting on long lines, not even for the first few characters. This
removes the hang and the delays.

Fixes issue #23.
