### PR TITLE
Fix issue with `termguicolors` option

### DIFF
--- a/plugin/quick_scope.vim
+++ b/plugin/quick_scope.vim
@@ -73,7 +73,7 @@ vnoremap <silent> <plug>(QuickScopeToggle) :<c-u>call <sid>toggle()<cr>
 " Colors ---------------------------------------------------------------------
 " Detect if the running instance of Vim acts as a GUI or terminal.
 function! s:get_term()
-  if has('gui_running') || (has('nvim') && $NVIM_TUI_ENABLE_TRUE_COLOR)
+  if has('gui_running') || (has('nvim') && $NVIM_TUI_ENABLE_TRUE_COLOR) || has('termguicolors')
     let term = 'gui'
   else
     let term ='cterm'


### PR DESCRIPTION
set termguicolors will let the terminal enable True Color mode.
Feature that #35 is pointed.
