### PR TITLE
clear highlight when vim session loses focus

### DIFF
--- a/plugin/quick_scope.vim
+++ b/plugin/quick_scope.vim
@@ -44,8 +44,8 @@ endif
 if !exists('g:qs_highlight_on_keys')
   " Vanilla mode. Highlight on cursor movement.
   augroup quick_scope
-    autocmd CursorMoved,InsertLeave,ColorScheme,BufEnter * call quick_scope#UnhighlightLine() | call quick_scope#HighlightLine(2, g:qs_accepted_chars)
-    autocmd InsertEnter,BufLeave,TabLeave,WinLeave * call quick_scope#UnhighlightLine()
+    autocmd CursorMoved,InsertLeave,ColorScheme,BufEnter,FocusGained * call quick_scope#UnhighlightLine() | call quick_scope#HighlightLine(2, g:qs_accepted_chars)
+    autocmd InsertEnter,BufLeave,TabLeave,WinLeave,FocusLost * call quick_scope#UnhighlightLine()
   augroup END
 else
   " Highlight on key press. Set an 'augmented' mapping for each defined key.


### PR DESCRIPTION
Hello, since buffer and tabs has been taken into consideration too,I think the vim session focus is also related to the #42 problem. So when using GVim or nvim,the hightlight will be cleared if the window focus is lost.