### PR TITLE
Removes code causing cursor bug in Linux console

### DIFF
--- a/autoload/quick_scope.vim
+++ b/autoload/quick_scope.vim
@@ -51,10 +51,6 @@ function! quick_scope#Ready() abort
   " Position of where a dummy cursor should be placed.
   let s:cursor = 0
 
-  " Terminal and gui cursors which will be hidden and shown.
-  let s:t_ve = &t_ve
-  let s:guicursor = &guicursor
-
   " Characters with secondary highlights. Modified by get_highlight_patterns()
   let s:chars_s = []
 
@@ -77,13 +73,6 @@ function! quick_scope#Aim(motion) abort
   " Add a dummy cursor since calling getchar() places the actual cursor on
   " the command line.
   let s:cursor = matchadd(g:qs_hi_group_cursor, '\%#', g:qs_hi_priority + 1)
-
-  " Save and hide the cursor on the command line.
-  let s:t_ve = &t_ve
-  let s:guicursor = &guicursor
-
-  set t_ve=
-  set guicursor=n:block-NONE
 
   " Silence 'Type :quit<Enter> to exit Vim' message on <c-c> during a
   " character search.
@@ -109,11 +98,6 @@ endfunction
 function! quick_scope#Reload() abort
   " Remove dummy cursor
   call matchdelete(s:cursor)
-
-  " Restore the cursor on the command line.
-  set guicursor&
-  let &t_ve = s:t_ve
-  let &guicursor = s:guicursor
 
   " Restore previous or default <c-c> functionality
   if exists('b:qs_prev_ctrl_c_map')


### PR DESCRIPTION
tl;dr this pull request resolves a bug where quick-scope causes the terminal cursor to change permanently, contrary to user-defined settings, in certain environments

I've removed code that tampers with the global cursor, both in GUI mode and in console mode. Specifically, these settings cause a bug in a 16 bit console terminal that permanently changes the cursor from an underline to a block. This bug lasts after Vim is exited.

Additionally, despite the noble effort to hide the cursor, the present solution (that I've removed) relies too much (my opinion) on global state being coordinated between function calls. I think the plugin's overall design is more elegant without this code.

Finally, I do not find a visible cursor annoying. If the reviewer finds a visible cursor unpalatable, we should probably still merge this pull request (since it causes an unrecoverable bug when using quick-scope in Console mode) and brainstorm more elegant solutions to the problem.

Thanks for this great plugin @unblevable ; it's made Vim that much more enjoyable for me.