### PR TITLE
Add buftype blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ keystrokes with Vim's built-in <kbd>f&lt;char&gt;</kbd> (which moves your cursor
   + [Customize colors](#customize-colors)
   + [Toggle highlighting](#toggle-highlighting)
   + [Disable on long lines](#disable-plugin-on-long-lines)
+  + [Blacklist buftypes](#blacklist-buftypes)
   + [Customize Accepted Characters](#accepted-characters)
   + [Lazy Highlight](#lazy-highlight)
 + [Moving Across a Line](#moving-across-a-line)
@@ -148,6 +149,16 @@ Turn off this plugin when the length of line is longer than `g:qs_max_chars`.
 " Your .vimrc
 
 let g:qs_max_chars=80
+```
+
+### Blacklist buftypes
+
+Setting `g:qs_buftype_blacklist` to a list of buffer types disables the plugin when
+entering certain `buftype`'s. For example, to disable this plugin when for terminals and
+floating windows without filetypes set, put the following in your `vimrc`:
+
+```vim
+let g:qs_buftype_blacklist = ['terminal', 'nofile']
 ```
 
 ### Accepted Characters

--- a/autoload/quick_scope.vim
+++ b/autoload/quick_scope.vim
@@ -13,7 +13,7 @@ endfunction
 " The direction can be 0 (backward), 1 (forward) or 2 (both). Targets are the
 " characters that can be highlighted.
 function! quick_scope#HighlightLine(direction, targets) abort
-  if g:qs_enable && (!exists('b:qs_local_disable') || !b:qs_local_disable)
+  if g:qs_enable && (!exists('b:qs_local_disable') || !b:qs_local_disable) && index(get(g:, 'qs_buftype_blacklist', []), &buftype) < 0
     let line = getline(line('.'))
     let len = strlen(line)
     let pos = col('.')

--- a/doc/quick-scope.txt
+++ b/doc/quick-scope.txt
@@ -22,6 +22,7 @@ License:            MIT
     4.4 Disable on lone lings.................. |qs-disable-on-longlines|
     4.5 Accepted Characters.................... |qs-accepted-chars|
     4.6 Lazy Highlight......................... |qs-lazy-highlight|
+    4.7 Blacklist Buftypes..................... |qs-buftype-blacklist|
   5. Motivation ............................... |qs-motivation|
   6. Bugs ..................................... |qs-bugs|
     6.1 Known bugs ............................ |qs-known-bugs|
@@ -196,6 +197,16 @@ to reduce the slowdown caused by vanilla highlight mode in large terminals.
 (default: `0`)
 >
   let g:qs_lazy_highlight = 1
+<
+
+4.7 BLACKLIST BUFTYPES                                  *qs-buftype-blacklist*
+------------------------------------------------------------------------------
+
+                                                      *g:qs_buftype_blacklist*
+The option `g:qs_buftype_blacklist` can be used to disable this plugin when
+entering certain `buftype`'s. (default: `[]`)
+>
+  let g:qs_buftype_blacklist = []
 <
 
  5. MOTIVATION                                                 *qs-motivation*

--- a/plugin/quick_scope.vim
+++ b/plugin/quick_scope.vim
@@ -45,6 +45,10 @@ if !exists('g:qs_accepted_chars')
   let g:qs_accepted_chars = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
 endif
 
+if !exists('g:qs_buftype_blacklist')
+  let g:qs_buftype_blacklist = []
+endif
+
 if !exists('g:qs_highlight_on_keys')
   " Vanilla mode. Highlight on cursor movement.
   augroup quick_scope


### PR DESCRIPTION
Closes #50

This allows the user to disable this plugin in terminals and floating windows where no filetype is set. Plugins such as coc-nvim make use of these types of floating windows.