### PR TITLE
Fix g:qs_accepted_chars always being case-insensitive

### DIFF
--- a/autoload/quick_scope.vim
+++ b/autoload/quick_scope.vim
@@ -274,7 +274,7 @@ function! s:get_highlight_patterns(line, cursor, end, targets) abort
       let [char_p, char_s] = ['', '']
 
       let is_first_word = 0
-    elseif (index(a:targets, char) != -1 && !g:qs_ignorecase) || index(a:targets, tolower(char)) != -1
+    elseif index(a:targets, g:qs_ignorecase ? tolower(char) : char) != -1
       if g:qs_ignorecase
         " When g:qs_ignorecase is set, make char_i the lowercase of char
         let char_i = tolower(char)


### PR DESCRIPTION
Currently
```vim
let g:qs_accepted_chars = [a-z, 0-9]
```
and
```vim
let g:qs_accepted_chars = [a-z, A-Z, 0-9]
```
behave the same.

The problem was in this line:

```vim
elseif (index(a:targets, char) != -1 && !g:qs_ignorecase) || index(a:targets, tolower(char)) != -1
```

If the character isn't found and `g:qs_ignorecase` set to false, it still fallbacks to `tolower(char)`. So `(index(a:targets, char) != -1 && !g:qs_ignorecase)` doesn't make a difference here.

I replaced it with:

```vim
elseif index(a:targets, g:qs_ignorecase ? tolower(char) : char) != -1
```