### PR TITLE
Add asynchronous highlighting delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,16 @@ to reduce the slowdown caused by vanilla highlight mode in large terminals.
 let g:qs_lazy_highlight = 1
 ```
 
+### Highlighting delay
+The option `g:qs_delay` can be used to set the delay duration after which the
+highlighting starts if the cursor is not moved. This option increases
+performance. Taken into account only if `g:qs_lazy_highlight` and
+`g:qs_highlight_on_keys` are not enabled. If you set this to 0, the
+highlighting will be synchronous. It requires `has('timers')`. (default: `50`)
+```vim
+let g:qs_delay = 0
+```
+
 ## Moving Across a Line
 This section provides a detailed look at the most common and useful options for
 moving your cursor across a line in Vim. When you are aware of the existing

--- a/autoload/quick_scope.vim
+++ b/autoload/quick_scope.vim
@@ -34,6 +34,30 @@ function! quick_scope#HighlightLine(direction, targets) abort
   endif
 endfunction
 
+function! quick_scope#HighlightLineDelayCallback(direction, targets, _id) abort
+  call quick_scope#UnhighlightLine()
+  call quick_scope#HighlightLine(a:direction, a:targets)
+endfunction
+
+let s:timer = -1
+
+function! quick_scope#HighlightLineDelay(direction, targets) abort
+  if g:qs_enable && g:qs_delay > 0
+    call timer_stop(s:timer)
+    let Cb = function('quick_scope#HighlightLineDelayCallback', [a:direction, a:targets])
+    let s:timer = timer_start(g:qs_delay, Cb)
+  else
+    call quick_scope#UnhighlightLine()
+    call quick_scope#HighlightLine(a:direction, a:targets)
+  endif
+endfunction
+
+function! quick_scope#StopTimer() abort
+  if g:qs_delay > 0
+    call timer_stop(s:timer)
+  endif
+endfunction
+
 function! quick_scope#UnhighlightLine() abort
   for m in filter(getmatches(), printf('v:val.group ==# "%s" || v:val.group ==# "%s"', g:qs_hi_group_primary, g:qs_hi_group_secondary))
     call matchdelete(m.id)

--- a/doc/quick-scope.txt
+++ b/doc/quick-scope.txt
@@ -160,6 +160,15 @@ to reduce the slowdown caused by vanilla highlight mode in large terminals.
 >
   let g:qs_lazy_highlight = 1
 <
+                                                                  *g:qs_delay*
+The delay duration after which the highlighting starts if the cursor is not
+moved. This option increases performance. Taken into account only if
+`g:qs_lazy_highlight` and `g:qs_highlight_on_keys` are not enabled. If you set
+this to 0, the highlighting will be synchronous. It requires `has('timers')`.
+(default: `50`)
+>
+  let g:qs_delay = 0
+<
 
  4.2 CUSTOMIZE COLORS                                    *qs-customize-colors*
 ------------------------------------------------------------------------------

--- a/plugin/quick_scope.vim
+++ b/plugin/quick_scope.vim
@@ -57,15 +57,19 @@ if !exists('g:qs_buftype_blacklist')
   let g:qs_buftype_blacklist = []
 endif
 
+if !exists('g:qs_delay')
+  let g:qs_delay = has('timers') ? 50 : 0
+endif
+
 if !exists('g:qs_highlight_on_keys')
   " Vanilla mode. Highlight on cursor movement.
   augroup quick_scope
     if g:qs_lazy_highlight
       autocmd CursorHold,InsertLeave,ColorScheme,WinEnter,BufEnter,FocusGained * call quick_scope#UnhighlightLine() | call quick_scope#HighlightLine(2, g:qs_accepted_chars)
     else
-      autocmd CursorMoved,InsertLeave,ColorScheme,WinEnter,BufEnter,FocusGained * call quick_scope#UnhighlightLine() | call quick_scope#HighlightLine(2, g:qs_accepted_chars)
+      autocmd CursorMoved,InsertLeave,ColorScheme,WinEnter,BufEnter,FocusGained * call quick_scope#HighlightLineDelay(2, g:qs_accepted_chars)
     endif
-    autocmd InsertEnter,BufLeave,TabLeave,WinLeave,FocusLost * call quick_scope#UnhighlightLine()
+    autocmd InsertEnter,BufLeave,TabLeave,WinLeave,FocusLost * call quick_scope#StopTimer() | call quick_scope#UnhighlightLine()
   augroup END
 else
   " Highlight on key press. Set an 'augmented' mapping for each defined key.


### PR DESCRIPTION
Adds `g:qs_delay` option.
If the option set to >0, the highlighting will begin only after `q:qs_delay` milliseconds if the cursor is not moved.

It adds almost not noticeable delay, but hugely increases performance, especially if one repeats hjkl or uses shift+click in terminals, without using `g:qs_lazy_highlight` or `g:qs_highlight_on_keys`.

For example, quick-scope was very laggy for me with syntax on + vim-airline + clojure syntax.

The option is enabled by default (if `has('timers')` is true) and set to 50 ms.

vim-cursorword uses similar approach:
https://github.com/itchyny/vim-cursorword/blob/cc8114226ceefb5cafe1890e0900d3efb7dab1fd/autoload/cursorword.vim#L44-L56