### PR TITLE
Allow overriding g:qs_hi_priority

### DIFF
--- a/plugin/quick_scope.vim
+++ b/plugin/quick_scope.vim
@@ -87,7 +87,7 @@ xnoremap <silent> <plug>(QuickScopeToggle) :<c-u>call quick_scope#Toggle()<cr>
 " Set the colors used for highlighting.
 function! s:set_highlight_colors()
   " Priority for overruling other highlight matches.
-  let g:qs_hi_priority = 1
+  let g:qs_hi_priority = get(g:, "qs_hi_priority", 1)
 
   " Highlight group marking first appearance of characters in a line.
   let g:qs_hi_group_primary = 'QuickScopePrimary'


### PR DESCRIPTION
This change removes the hardcoded `g:qs_hi_priority` variables value. Now it is first checked if this variable is defined. This allows to set `g:qs_hi_priority` in .vimrc file to achieve custom priority for the quick-scope.