### PR TITLE
Adds wallhacks

### DIFF
--- a/autoload/quick_scope.vim
+++ b/autoload/quick_scope.vim
@@ -1,6 +1,7 @@
 " Autoload interface functions -------------------------------------------------
 
 function! quick_scope#Wallhacks(motion=2) abort
+  call quick_scope#Ready()
   if (a:motion ==? 'f')
     let direction = 1
   elseif (a:motion ==? 't')
@@ -10,16 +11,19 @@ function! quick_scope#Wallhacks(motion=2) abort
   endif
 
   augroup quick_scope_wallhacks
-    autocmd CursorMoved,InsertLeave,ColorScheme,WinEnter,BufEnter,FocusGained,InsertEnter,BufLeave,TabLeave,WinLeave,FocusLost * ++once call quick_scope#UnhighlightLine()
-    if !g:qs_lazy_highlight
+    autocmd CursorMoved,ColorScheme,FocusGained,InsertEnter,BufLeave,TabLeave,WinLeave,FocusLost * ++once call quick_scope#UnhighlightLine()
+    if g:qs_lazy_highlight
       autocmd InsertEnter,BufLeave,TabLeave,WinLeave,FocusLost * ++once call quick_scope#StopTimer()
     endif
   augroup END
+
   if g:qs_lazy_highlight
-    call quick_scope#HighlightLine(direction, g:qs_accepted_chars)
-  else
     call quick_scope#HighlightLineDelay(direction, g:qs_accepted_chars)
+  else
+    call quick_scope#HighlightLine(direction, g:qs_accepted_chars)
+    redraw
   endif
+  return ''
 endfunction
 
 function! quick_scope#Toggle() abort

--- a/autoload/quick_scope.vim
+++ b/autoload/quick_scope.vim
@@ -1,5 +1,27 @@
 " Autoload interface functions -------------------------------------------------
 
+function! quick_scope#Wallhacks(motion=2) abort
+  if (a:motion ==? 'f')
+    let direction = 1
+  elseif (a:motion ==? 't')
+    let direction = 0
+  else
+    let direction = a:motion
+  endif
+
+  augroup quick_scope_wallhacks
+    autocmd CursorMoved,InsertLeave,ColorScheme,WinEnter,BufEnter,FocusGained,InsertEnter,BufLeave,TabLeave,WinLeave,FocusLost * ++once call quick_scope#UnhighlightLine()
+    if !g:qs_lazy_highlight
+      autocmd InsertEnter,BufLeave,TabLeave,WinLeave,FocusLost * ++once call quick_scope#StopTimer()
+    endif
+  augroup END
+  if g:qs_lazy_highlight
+    call quick_scope#HighlightLine(direction, g:qs_accepted_chars)
+  else
+    call quick_scope#HighlightLineDelay(direction, g:qs_accepted_chars)
+  endif
+endfunction
+
 function! quick_scope#Toggle() abort
   if g:qs_enable
     let g:qs_enable = 0

--- a/autoload/quick_scope.vim
+++ b/autoload/quick_scope.vim
@@ -11,6 +11,9 @@ function! quick_scope#Wallhacks(motion=2) abort
   endif
 
   augroup quick_scope_wallhacks
+    for useraucmd in g:qs_augrp_clean
+      execute printf('autocmd User ' .  useraucmd . 'call quick_scope#UnhighlightLine()')
+    endfor
     autocmd CursorMoved,ColorScheme,FocusGained,InsertEnter,BufLeave,TabLeave,WinLeave,FocusLost * ++once call quick_scope#UnhighlightLine()
     if g:qs_lazy_highlight
       autocmd InsertEnter,BufLeave,TabLeave,WinLeave,FocusLost * ++once call quick_scope#StopTimer()

--- a/plugin/quick_scope.vim
+++ b/plugin/quick_scope.vim
@@ -87,6 +87,12 @@ else
   endfor
 endif
 
+for mapmode in ['nnoremap', 'onoremap', 'xnoremap']
+  for motion in split('FT', '\zs')
+    execute printf(mapmode . ' <expr> <Plug>(QuickScopeWallhacks%s) quick_scope#Wallhacks("%s")', motion, motion)
+  endfor
+  execute printf(mapmode . ' <expr> <Plug>(QuickScopeWallhacks) quick_scope#Wallhacks()')
+endfor
 " User commands --------------------------------------------------------------
 command! -nargs=0 QuickScopeToggle call quick_scope#Toggle()
 

--- a/plugin/quick_scope.vim
+++ b/plugin/quick_scope.vim
@@ -57,6 +57,10 @@ if !exists('g:qs_buftype_blacklist')
   let g:qs_buftype_blacklist = []
 endif
 
+if !exists('g:qs_augrp_clean')
+  let g:qs_augrp_clean = ['EasyMotionPromptBegin']
+endif
+
 if !exists('g:qs_delay')
   let g:qs_delay = has('timers') ? 50 : 0
 endif

--- a/plugin/quick_scope.vim
+++ b/plugin/quick_scope.vim
@@ -57,6 +57,10 @@ if !exists('g:qs_buftype_blacklist')
   let g:qs_buftype_blacklist = []
 endif
 
+if !exists('g:qs_filetype_blacklist')
+  let g:qs_filetype_blacklist = []
+endif
+
 if !exists('g:qs_augrp_clean')
   let g:qs_augrp_clean = ['EasyMotionPromptBegin']
 endif


### PR DESCRIPTION
Just hacking/procastinating, does good enough for my usecase, so ymmv.
New variable set to: `g:qs_augrp_clean = ['EasyMotionPromptBegin']`

For example usage:
`nmap f <Plug>(QuickScopeWallHacksF)<Plug>(easmotion-fl)`. It's not perfect but it helps.

As a follow up to [pr-71](https://github.com/unblevable/quick-scope/pull/71#issuecomment-834517800) and may help with issue [#55].

You probably don't want to merge until some others have tried this out.