### PR TITLE
Add filetype blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ keystrokes with Vim's built-in <kbd>f&lt;char&gt;</kbd> (which moves your cursor
   + [Toggle highlighting](#toggle-highlighting)
   + [Disable on long lines](#disable-plugin-on-long-lines)
   + [Blacklist buftypes](#blacklist-buftypes)
+  + [Blacklist filetypes](#blacklist-filetypes)
   + [Customize Accepted Characters](#accepted-characters)
   + [Lazy Highlight](#lazy-highlight)
 + [Moving Across a Line](#moving-across-a-line)
@@ -166,6 +167,17 @@ floating windows without filetypes set, put the following in your `vimrc`:
 
 ```vim
 let g:qs_buftype_blacklist = ['terminal', 'nofile']
+```
+
+### Blacklist filetypes
+
+Setting `g:qs_filetype_blacklist` to a list of file types disables the plugin when
+entering certain `filetypes`'s. For example, to disable this plugin for
+[dashboard-nvim](https://github.com/glepnir/dashboard-nvim) and
+[vim-startify](https://github.com/mhinz/vim-startify), put the following in your `vimrc`:
+
+```vim
+let g:qs_filetype_blacklist = ['dashboard', 'startify']
 ```
 
 ### Accepted Characters

--- a/autoload/quick_scope.vim
+++ b/autoload/quick_scope.vim
@@ -13,7 +13,7 @@ endfunction
 " The direction can be 0 (backward), 1 (forward) or 2 (both). Targets are the
 " characters that can be highlighted.
 function! quick_scope#HighlightLine(direction, targets) abort
-  if g:qs_enable && (!exists('b:qs_local_disable') || !b:qs_local_disable) && index(get(g:, 'qs_buftype_blacklist', []), &buftype) < 0
+  if g:qs_enable && (!exists('b:qs_local_disable') || !b:qs_local_disable) && index(get(g:, 'qs_buftype_blacklist', []), &buftype) && index(get(g:, 'qs_filetype_blacklist', []), &filetype) < 0
     let line = getline(line('.'))
     let len = strlen(line)
     let pos = col('.')

--- a/doc/quick-scope.txt
+++ b/doc/quick-scope.txt
@@ -139,6 +139,12 @@ entering certain |buftype|'s. (default: `[]`)
 >
   let g:qs_buftype_blacklist = ['terminal', 'nofile']
 <
+                                                      *g:qs_filetype_blacklist*
+The option `g:qs_filetype_blacklist` can be used to disable this plugin when
+entering certain |filetype|'s. (default: `[]`)
+>
+  let g:qs_filetype_blacklist = ['dashboard', 'startify']
+<
                                                               *g:qs_max_chars*
 Turn off this plugin when the length of a line is longer than
 `g:qs_max_chars`. (default: `1000`)

--- a/plugin/quick_scope.vim
+++ b/plugin/quick_scope.vim
@@ -57,6 +57,10 @@ if !exists('g:qs_buftype_blacklist')
   let g:qs_buftype_blacklist = []
 endif
 
+if !exists('g:qs_filetype_blacklist')
+  let g:qs_filetype_blacklist = []
+endif
+
 if !exists('g:qs_delay')
   let g:qs_delay = has('timers') ? 50 : 0
 endif


### PR DESCRIPTION
Complements https://github.com/unblevable/quick-scope/pull/52. 

Since (neo)vim defaults the buftype to an empty string, buftype blacklist can't be used for disabling quick-scope for plugins like [dashboard-nvim](https://github.com/glepnir/dashboard-nvim) and [vim-startify](https://github.com/mhinz/vim-startify) without affecting file types where quick-scope is desired. This pull request makes it possible to disable quick-scope on selected file types.

Also, adding an empty to string to `g:qs_filetype_blacklist` list effectively turns off quick-scope for the terminal and other buf types that don't have a file type set, although it doesn't allow as much control as using `g:qs_buftype_blacklist`, so I left buftype blacklist unchanged. 