### PR TITLE
Fix errors with `highlight_on_keys`

### DIFF
--- a/autoload/quick_scope.vim
+++ b/autoload/quick_scope.vim
@@ -90,7 +90,11 @@ endfunction
 
 " Returns {character motion}{captured char} (to map to a character motion) to
 " emulate one as closely as possible.
-function! quick_scope#Aim(motion) abort
+function! quick_scope#Aim(motion, ...) abort
+  " We don't use <expr> for normal mode mappings so we need this function to
+  " execute the motion command directly
+  let should_execute = get(a:, 1, 0)
+
   if (a:motion ==# 'f' || a:motion ==# 't')
     let s:direction = 1
   else
@@ -119,6 +123,9 @@ function! quick_scope#Aim(motion) abort
   let char = getchar()
   let s:target = char ==# "\<S-lt>" ? '<' : nr2char(char)
 
+  if should_execute
+    execute 'normal! '.a:motion.s:target
+  endif
   return a:motion . s:target
 endfunction
 

--- a/autoload/quick_scope.vim
+++ b/autoload/quick_scope.vim
@@ -90,11 +90,7 @@ endfunction
 
 " Returns {character motion}{captured char} (to map to a character motion) to
 " emulate one as closely as possible.
-function! quick_scope#Aim(motion, ...) abort
-  " We don't use <expr> for normal mode mappings so we need this function to
-  " execute the motion command directly
-  let should_execute = get(a:, 1, 0)
-
+function! quick_scope#Aim(motion) abort
   if (a:motion ==# 'f' || a:motion ==# 't')
     let s:direction = 1
   else
@@ -123,9 +119,6 @@ function! quick_scope#Aim(motion, ...) abort
   let char = getchar()
   let s:target = char ==# "\<S-lt>" ? '<' : nr2char(char)
 
-  if should_execute
-    execute 'normal! '.a:motion.s:target
-  endif
   return a:motion . s:target
 endfunction
 

--- a/autoload/quick_scope/mapping.vim
+++ b/autoload/quick_scope/mapping.vim
@@ -7,5 +7,5 @@ function! quick_scope#mapping#Restore(mapping) abort
         \ . (a:mapping.nowait ? '<nowait> ' : '')
         \ . (a:mapping.silent ? '<silent> ' : '')
         \ . a:mapping.lhs . ' '
-        \ . substitute(a:mapping.rhs, '<SID>', '<SNR>' . a:mapping.sid . '_', 'g')
+        \ . substitute(escape(a:mapping.rhs, '|'), '<SID>', '<SNR>' . a:mapping.sid . '_', 'g')
 endfunction

--- a/plugin/quick_scope.vim
+++ b/plugin/quick_scope.vim
@@ -78,9 +78,11 @@ if !exists('g:qs_highlight_on_keys')
 else
   " Highlight on key press. Set an 'augmented' mapping for each defined key.
   for motion in split('fFtT', '\zs')
-    for mapmode in ['nnoremap', 'onoremap', 'xnoremap']
+    for mapmode in ['onoremap', 'xnoremap']
       execute printf(mapmode . ' <expr> <Plug>(QuickScope%s) quick_scope#Ready() . quick_scope#Aim("%s") . quick_scope#Reload() . quick_scope#DoubleTap()', motion, motion)
     endfor
+    " Using <expr> for normal mode mappings can cause problems (#80)
+    execute printf('nnoremap <silent> <Plug>(QuickScope%s) :<C-U>call quick_scope#Ready() \| call quick_scope#Aim("%s", 1) \| call quick_scope#Reload() \| call quick_scope#DoubleTap()<CR>', motion, motion)
   endfor
   for motion in filter(g:qs_highlight_on_keys, "v:val =~# '^[fFtT]$'")
     for mapmode in ['nmap', 'omap', 'xmap']

--- a/plugin/quick_scope.vim
+++ b/plugin/quick_scope.vim
@@ -82,7 +82,7 @@ else
       execute printf(mapmode . ' <expr> <Plug>(QuickScope%s) quick_scope#Ready() . quick_scope#Aim("%s") . quick_scope#Reload() . quick_scope#DoubleTap()', motion, motion)
     endfor
     " Using <expr> for normal mode mappings can cause problems (#80)
-    execute printf('nnoremap <silent> <Plug>(QuickScope%s) :<C-U>call quick_scope#Ready() \| call quick_scope#Aim("%s", 1) \| call quick_scope#Reload() \| call quick_scope#DoubleTap()<CR>', motion, motion)
+    execute printf('nnoremap <silent> <Plug>(QuickScope%s) :<C-U>call quick_scope#Ready() \| execute "normal!" quick_scope#Aim("%s") \| call quick_scope#Reload() \| call quick_scope#DoubleTap()<CR>', motion, motion)
   endfor
   for motion in filter(g:qs_highlight_on_keys, "v:val =~# '^[fFtT]$'")
     for mapmode in ['nmap', 'omap', 'xmap']


### PR DESCRIPTION
This should fix #80 by:
* Avoiding the use of `<expr>` mappings for normal mode
* Escaping the `|` character when restoring key mappings