### PR TITLE
Fix mappings when no count is given

### DIFF
--- a/plugin/quick_scope.vim
+++ b/plugin/quick_scope.vim
@@ -82,7 +82,7 @@ else
       execute printf(mapmode . ' <expr> <Plug>(QuickScope%s) quick_scope#Ready() . quick_scope#Aim("%s") . quick_scope#Reload() . quick_scope#DoubleTap()', motion, motion)
     endfor
     " Using <expr> for normal mode mappings can cause problems (#80)
-    execute printf('nnoremap <silent> <Plug>(QuickScope%s) :<C-U>call quick_scope#Ready() \| execute "normal!" v:count . quick_scope#Aim("%s") \| call quick_scope#Reload() \| call quick_scope#DoubleTap()<CR>', motion, motion)
+    execute printf('nnoremap <silent> <Plug>(QuickScope%s) :<C-U>call quick_scope#Ready() \| execute "normal!" v:count1 . quick_scope#Aim("%s") \| call quick_scope#Reload() \| call quick_scope#DoubleTap()<CR>', motion, motion)
   endfor
   for motion in filter(g:qs_highlight_on_keys, "v:val =~# '^[fFtT]$'")
     for mapmode in ['nmap', 'omap', 'xmap']


### PR DESCRIPTION
Since 9fb216a843db241e1caf0661e29d3df156d09af6, f/F were broken when you are trying to jump to the same letter your cursor is already under: instead of jumping to the next occurrence, it did nothing instead (NVIM v0.6.1).

I believe this is because `v:count` expands to zero if no count has been giving. Using `v:count1` instead fixes the issue for me, as that expands to `1`.