### PR TITLE
Disable redraw when using lazyredraw

### DIFF
--- a/autoload/quick_scope.vim
+++ b/autoload/quick_scope.vim
@@ -115,7 +115,9 @@ function! quick_scope#Aim(motion) abort
 
   call quick_scope#HighlightLine(s:direction, g:qs_accepted_chars)
 
-  redraw
+  if !&lazyredraw
+    redraw
+  endif
 
   " Store and capture the target for the character motion.
   let char = getchar()


### PR DESCRIPTION
The vim setting `lazyredraw` is useful to prevent the screen refreshing whilst a macro is being running - it will wait until the macro is finished before redrawing. This can help to speed up macros

Currently, quick-scope calls the `redraw` function directly. This means that, if `qs_highlight_on_keys` is set, using these keys during a macro will force a `redraw` and therefore basically make `lazyredraw` ineffective

This change checks that `lazyredraw` is not set before it redraws, which allows macros to still by run quickly using `lazyredraw`
