### PR TITLE
fix(ci): bump luarocks-tag release version + enable PR test runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,13 +3,14 @@ on:
   push:
     tags:
       - 'v*'
+  pull_request:
 jobs:
   luarocks-upload:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: LuaRocks Upload
-        uses: nvim-neorocks/luarocks-tag-release@v4
+        uses: nvim-neorocks/luarocks-tag-release@v5
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
         with:


### PR DESCRIPTION
There was a bug in the luarocks-tag-release workflow, preventing the `plugin` and `autoload` directories from being added to the luarocks package.

The latest version of the workflow fixes it, so I've bumped it here.
I've also added `pull_request` as a trigger, so it can run (without uploading to luarocks) on PRs.

This time, I've manually tested it in Neovim with the following minimal config:

```lua
-- minimal.lua
-- Copy this to an empty test directory and start with
-- luarocks install --tree $(realpath .) quick-scope
-- nvim -u minimal.lua test.txt

-- Ignore default config
local config_path = vim.fn.stdpath('config')
vim.opt.rtp:remove(config_path)

-- Ignore default plugins
local data_path = vim.fn.stdpath('data')
local pack_path = data_path .. '/site'
vim.opt.packpath:remove(pack_path)

vim.opt.runtimepath:append('lib/luarocks/rocks-5.1/quick-scope/scm-1/')
```

...and it works :tada: 

![image](https://github.com/unblevable/quick-scope/assets/12857160/ea7bd712-6227-486f-ba21-d9ba44de910c)

