### PR TITLE
fix: use vararg in quick_scope#Wallhacks for Vim 8.0 compatibility

### DIFF
--- a/autoload/quick_scope.vim
+++ b/autoload/quick_scope.vim
@@ -1,13 +1,14 @@
 " Autoload interface functions -------------------------------------------------
 
-function! quick_scope#Wallhacks(motion=2) abort
+function! quick_scope#Wallhacks(...) abort
+  let l:motion = a:0 > 0 ? a:1 : 2
   call quick_scope#Ready()
-  if (a:motion ==? 'f')
+  if (l:motion ==? 'f')
     let direction = 1
-  elseif (a:motion ==? 't')
+  elseif (l:motion ==? 't')
     let direction = 0
   else
-    let direction = a:motion
+    let direction = l:motion
   endif
 
   augroup quick_scope_wallhacks


### PR DESCRIPTION
Fix for #101.
Vim 8.0 and earlier do not support default argument values in function definitions
Replace the default value with vararg to ensure compatibility across Vim versions.